### PR TITLE
change type of v_mview_expression to allow larger expressions

### DIFF
--- a/flexviews/procs/add_expr.sql
+++ b/flexviews/procs/add_expr.sql
@@ -101,7 +101,7 @@ DROP PROCEDURE IF EXISTS flexviews.`add_expr` ;;
 CREATE DEFINER=`flexviews`@`localhost` PROCEDURE flexviews.`add_expr`(
   IN v_mview_id INT,
   IN v_mview_expr_type TINYTEXT CHARACTER SET UTF8,
-  IN v_mview_expression TINYTEXT CHARACTER SET UTF8,
+  IN v_mview_expression TEXT CHARACTER SET UTF8,
   IN v_mview_alias TINYTEXT CHARACTER SET UTF8
 )
 BEGIN

--- a/flexviews/procs/delta.sql
+++ b/flexviews/procs/delta.sql
@@ -959,7 +959,7 @@ CREATE DEFINER=flexviews@localhost FUNCTION flexviews.get_delta_groupby(
 BEGIN  
 DECLARE v_done boolean DEFAULT FALSE;  
 DECLARE v_mview_expr_type TINYTEXT CHARACTER SET UTF8;  
-DECLARE v_mview_expression TINYTEXT CHARACTER SET UTF8; 
+DECLARE v_mview_expression TEXT CHARACTER SET UTF8; 
 DECLARE v_mview_alias TINYTEXT CHARACTER SET UTF8;  
 DECLARE v_group_list MEDIUMTEXT CHARACTER SET UTF8 default '';  
 DECLARE v_mview_alias_prefixed TINYTEXT CHARACTER SET UTF8;

--- a/flexviews/procs/get_grouping_list.sql
+++ b/flexviews/procs/get_grouping_list.sql
@@ -27,7 +27,7 @@ CREATE DEFINER=flexviews@localhost FUNCTION flexviews.get_delta_groupby(
 BEGIN  
 DECLARE v_done boolean DEFAULT FALSE;  
 DECLARE v_mview_expr_type TINYTEXT CHARACTER SET UTF8;  
-DECLARE v_mview_expression TINYTEXT CHARACTER SET UTF8; 
+DECLARE v_mview_expression TEXT CHARACTER SET UTF8; 
 DECLARE v_mview_alias TINYTEXT CHARACTER SET UTF8;  
 DECLARE v_group_list TEXT CHARACTER SET UTF8 default '' ;
 DECLARE v_mview_alias_prefixed TINYTEXT CHARACTER SET UTF8;


### PR DESCRIPTION
changed the type of v_mview_expression from TINYTEXT to TEXT as it wasn't large enough to hold the hashes being generated for some tables.
modified:   flexviews/procs/add_expr.sql
modified:   flexviews/procs/delta.sql
modified:   flexviews/procs/get_grouping_list.sql
