### PR TITLE
Fix hasStopNever issue on MacOSX

### DIFF
--- a/flexviews/consumer/include/flexcdc.php
+++ b/flexviews/consumer/include/flexcdc.php
@@ -228,7 +228,7 @@ EOREGEX
 		if(!$this->cmdLine) {
 			die1("could not find mysqlbinlog!",2);
 		}
-		$this->hasStopNever = (bool)system($this->cmdLine . ' --help | grep stop-never|wc -l');
+		$this->hasStopNever = (bool)trim(system($this->cmdLine . ' --help | grep stop-never|wc -l'));
 		$this->settings = $settings;
 		
 		


### PR DESCRIPTION
On MacOSX wc -l returns a result with trailing space. It needs to be trimmed to have hasStopNever properly set.