### PR TITLE
flexcdc: do not overescape bit fields

### DIFF
--- a/flexviews/consumer/include/flexcdc.php
+++ b/flexviews/consumer/include/flexcdc.php
@@ -81,6 +81,7 @@ class FlexCDC {
 			if(strtoupper($col) === "NULL") $datatype="NULL";
 			switch(trim($datatype)) {
 				case 'NULL':
+				case 'bit':
 				break;
 
 				case 'int':


### PR DESCRIPTION
Bit fields are logged as b'010101', they shouldn't result in 'b'010101' in the
changelog query. Ignore them as they're ready to insert.